### PR TITLE
Pin pydocstyle to lower than 4.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     rev: 3.7.7
     hooks:
       - id: flake8
-        additional_dependencies: ["flake8-docstrings"]
+        additional_dependencies: ["flake8-docstrings", "pydocstyle<4.0.0"]
   - repo: https://github.com/adrienverge/yamllint.git
     sha: v1.15.0
     hooks:


### PR DESCRIPTION
For now pin pydocstyle because it is broken in 4.0.0

https://github.com/PyCQA/pydocstyle/issues/375