### PR TITLE
Protect against None value in housenumber letter

### DIFF
--- a/src/twentemilieu/twentemilieu.py
+++ b/src/twentemilieu/twentemilieu.py
@@ -135,7 +135,7 @@ class TwenteMilieu:
                     "companyCode": self.company_code,
                     "postCode": self.post_code,
                     "houseNumber": str(self.house_number),
-                    "houseLetter": str(self.house_letter),
+                    "houseLetter": str(self.house_letter or ""),
                 },
             )
             if "dataList" not in response or not response["dataList"]:


### PR DESCRIPTION
# Proposed Changes

Ensure we always send an empty string for the house letters, even if the software using this library sends a `NoneType` value.
