### PR TITLE
Fix devcontainer python version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,7 @@
   "features": {
     "ghcr.io/devcontainers-contrib/features/poetry:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/node:1": {}
   },
   "image": "mcr.microsoft.com/devcontainers/python:3",
   "name": "Asynchronous Python client for Twente Milieu API",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,11 +47,8 @@
     "ghcr.io/devcontainers-contrib/features/poetry:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers/features/python:1": {
-      "installTools": false
-    }
   },
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/python:3",
   "name": "Asynchronous Python client for Twente Milieu API",
   "updateContentCommand": ". ${NVM_DIR}/nvm.sh && nvm install && nvm use && npm install && poetry install && poetry run pre-commit install"
 }


### PR DESCRIPTION
When i tried starting the project using the provided devcontainer poetry failed because the built-in python version (3.10) was too old

# Proposed Changes

Replace the base image with the updated python devcontainer base image that does contain the up-to date python version