### PR TITLE
Add support for similar waste types with different API IDs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,5 +50,5 @@
   },
   "image": "mcr.microsoft.com/devcontainers/python:3",
   "name": "Asynchronous Python client for Twente Milieu API",
-  "updateContentCommand": ". ${NVM_DIR}/nvm.sh && nvm install && nvm use && npm install && poetry install && poetry run pre-commit install"
+  "updateContentCommand": "git config --global --add safe.directory '*' && . ${NVM_DIR}/nvm.sh && nvm install && nvm use && npm install && poetry install && poetry run pre-commit install"
 }

--- a/src/twentemilieu/twentemilieu.py
+++ b/src/twentemilieu/twentemilieu.py
@@ -34,6 +34,27 @@ class WasteType(IntEnum):
     TREE = 6
     PACKAGES = 10
 
+    @classmethod
+    def _missing_(cls, value: object) -> WasteType:
+        """Fallback for unknown waste types.
+
+        Some waste types returned from the Twente Milieu API are semantically the same
+        as some types already defined in this enum. This maps the API value to the
+        correct enum value.
+
+        An example would be for packages. Some housing has a container for packages,
+        and high-density living may need to place their packages at a central point
+        for pick-up. Both is a pick-up for packages, but their waste type returned
+        from the API are different.
+
+        """
+        if not isinstance(value, int):
+            raise TypeError(value)
+
+        return {
+            56: WasteType.PACKAGES,
+        }[value]
+
 
 @dataclass
 class TwenteMilieu:

--- a/tests/test_twentemilieu.py
+++ b/tests/test_twentemilieu.py
@@ -40,6 +40,16 @@ async def test_json_request(aresponses: ResponsesMockServer) -> None:
         await twente.close()
 
 
+async def test_wastetype_fallback() -> None:
+    """Test the WasteType fallback is handled correctly."""
+    assert (
+        WasteType(56) == WasteType.PACKAGES
+    ), "Fallback for high-density packages not handled!"
+
+    with pytest.raises(TypeError):
+        WasteType._missing_("wrong_type")
+
+
 async def test_internal_session(aresponses: ResponsesMockServer) -> None:
     """Test JSON response is handled correctly."""
     aresponses.add(
@@ -238,6 +248,10 @@ async def test_update(aresponses: ResponsesMockServer) -> None:
                             "pickupDates": ["2019-07-22T00:00:00"],
                             "pickupType": 2,
                         },
+                        {
+                            "pickupDates": ["2019-07-23T00:00:00"],
+                            "pickupType": 56,
+                        },
                         {"pickupDates": [], "pickupType": 10},
                     ],
                 },
@@ -255,4 +269,4 @@ async def test_update(aresponses: ResponsesMockServer) -> None:
         ]
         assert pickups[WasteType.ORGANIC] == [date(2019, 7, 19), date(2019, 7, 20)]
         assert pickups[WasteType.PAPER] == [date(2019, 7, 22)]
-        assert not pickups[WasteType.PACKAGES]
+        assert pickups[WasteType.PACKAGES] == [date(2019, 7, 23)]


### PR DESCRIPTION
# Proposed Changes

This PR adds a fall-through method to the `WasteType` enum. The Twente Milieu API might return a waste type that is almost the same as one already defined in the enum.

Hengelo now has pick-up points for packaging and paper for high-density living. For the packaging, they created a new waste type. However, it is still packaging. This change now maps the 'odd' waste type returned from the API to the packages value in the enum.

Please let me know what you think!

## Related Issues

https://github.com/frenck/python-twentemilieu/issues/1265